### PR TITLE
Update readme for windows compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ resized to at most 4K pixels on each side by default.
 
 You should be able to run the app using `cargo run --release`.
 
+### Windows
+If compilation fails with "'stdio.h' file not found", try running in `Developer Command Prompt for VS 2022/2019` or `Developer PowerShell for VS`.
+
 ## Supported image formats
 
 The panorama can be stored either in any format that the Rust [`image`] crate


### PR DESCRIPTION
I had some trouble compiling, when I had the necessary VisualStudio tools installed. The solution was simply to use a special terminal for VisualStudio compilation.

This PR updates Readme to let Windows users know about the Developer Command Prompt for VS in case of "'stdio.h' file not found" error.