### PR TITLE
Fix build and link errors.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ fn main() {
         .include(gltf_ibl_sampler_dir.join("thirdparty/stb"))
         .include(gltf_ibl_sampler_dir.join("thirdparty/volk"))
         .include(gltf_ibl_sampler_dir.join("thirdparty/Vulkan-Headers/include"))
+        .cpp(true)
         .compile("IBLLib");
     for source_file in &gltf_ibl_sampler_src {
         // FIXME: This should include headers too.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -85,7 +85,7 @@ pub(crate) enum InputReencodingStatus {
     Reencoded,
 }
 
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Default, Display)]
 pub(crate) enum OutputError {
     VulkanInitializationFailed = IBLLib_Result_VulkanInitializationFailed,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -88,15 +88,15 @@ pub(crate) enum InputReencodingStatus {
 #[repr(u32)]
 #[derive(Default, Display)]
 pub(crate) enum OutputError {
-    VulkanInitializationFailed = IBLLib_Result_VulkanInitializationFailed,
-    VulkanError = IBLLib_Result_VulkanError,
-    InputPanoramaFileNotFound = IBLLib_Result_InputPanoramaFileNotFound,
-    ShaderFileNotFound = IBLLib_Result_ShaderFileNotFound,
-    ShaderCompilationFailed = IBLLib_Result_ShaderCompilationFailed,
-    FileNotFound = IBLLib_Result_FileNotFound,
-    InvalidArgument = IBLLib_Result_InvalidArgument,
-    KtxError = IBLLib_Result_KtxError,
-    StbError = IBLLib_Result_StbError,
+    VulkanInitializationFailed = IBLLib_Result_VulkanInitializationFailed as u32,
+    VulkanError = IBLLib_Result_VulkanError as u32,
+    InputPanoramaFileNotFound = IBLLib_Result_InputPanoramaFileNotFound as u32,
+    ShaderFileNotFound = IBLLib_Result_ShaderFileNotFound as u32,
+    ShaderCompilationFailed = IBLLib_Result_ShaderCompilationFailed as u32,
+    FileNotFound = IBLLib_Result_FileNotFound as u32,
+    InvalidArgument = IBLLib_Result_InvalidArgument as u32,
+    KtxError = IBLLib_Result_KtxError as u32,
+    StbError = IBLLib_Result_StbError as u32,
     #[default]
     OutputCubemapPathNotValidUTF8,
     OutputLutPathNotValidUTF8,


### PR DESCRIPTION
Building is currently broken on linux (didn't test windows or mac).
`.cpp(true)` is needed to fix linker errors due to libstdc++ not being included and `gltf_ibl_sampler` using things from it.

Draft for now as it also needs https://github.com/pcwalton/glTF-IBL-Sampler/pull/1 and then a submodule update.

This should fix https://github.com/pcwalton/gltf-ibl-sampler-egui/issues/7